### PR TITLE
Add a --verbose flag to help diagnose build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ OPTIONS
   -d, --destination=destination  [default: ./dist] defines the directory where the build is stored
   -m, --mode=mode                [default: development] defines the mode for the build (production|development)
   -n, --noclear                  setting this will not re-create the build dir
+  -v, --verbose                  print the webpack build configuration to console
   -w, --webpack=webpack          location of custom webpack configuration file
 
 EXAMPLES

--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -58,6 +58,11 @@ export default class Build extends Command {
             description: messages.flags.noclear,
             default: lwcConfig.noclear
         }),
+        verbose: flags.boolean({
+            char: 'v',
+            description: messages.flags.verbose,
+            default: false
+        }),
         webpack: flags.string({
             char: 'w',
             description: messages.flags.webpack
@@ -124,6 +129,15 @@ export default class Build extends Command {
                 process.cwd(),
                 flags.destination
             )
+        }
+
+        if (flags.verbose) {
+            log(messages.logs.webpack_config);
+            let jsonConfig: string = JSON.stringify(webpackConfig, null, 2);
+            log({
+                message: jsonConfig,
+                emoji: 'hammer'
+            });
         }
 
         try {

--- a/packages/lwc-services/src/messages/build.ts
+++ b/packages/lwc-services/src/messages/build.ts
@@ -10,6 +10,7 @@ export const messages = {
         mode: 'defines the mode for the build (production|development)',
         destination: 'defines the directory where the build is stored',
         noclear: 'setting this will not re-create the build dir',
+        verbose: 'print the webpack build configuration to console',
         webpack: 'location of custom webpack configuration file'
     },
     errors: {
@@ -46,6 +47,10 @@ export const messages = {
         custom_configuration: {
             message: 'Using custom configuration from webpack.config.js.',
             emoji: 'star2'
+        },
+        webpack_config: {
+            message: 'Webpack build config:',
+            emoji: 'hammer'
         }
     }
 }


### PR DESCRIPTION
Hi there,

This PR adds a `--verbose` flag to the `lwc-services` CLI.  Currently it just prints out the final Webpack build configuration.

We needed this functionality to help us debug build failures in an app that makes heavy use of private modules.

Note: currently we are working with internal Salesforce teams to bring LWC functionality to our Pulsar for Salesforce offline mobile app.

Kind regards,

Aaron Culliney
Luminix, Inc