### PR TITLE
fix: Windows does not like single quotes in package.json prettier commands

### DIFF
--- a/packages/create-lwc-app/src/generators/createGenerator.ts
+++ b/packages/create-lwc-app/src/generators/createGenerator.ts
@@ -236,9 +236,9 @@ class CreateGenerator extends Generator {
             this.pjson.scripts.lint = 'eslint ./src/**/*.js'
         }
         this.pjson.scripts.prettier =
-            "prettier --write '**/*.{css,html,js,json,md,ts,yaml,yml}'"
+            "prettier --write \"**/*.{css,html,js,json,md,ts,yaml,yml}\""
         this.pjson.scripts['prettier:verify'] =
-            "prettier --list-different '**/*.{css,html,js,json,md,ts,yaml,yml}'"
+            "prettier --list-different \"**/*.{css,html,js,json,md,ts,yaml,yml}\""
         if (this.clientserver) {
             if (this.typescript) {
                 this.pjson.scripts.build =


### PR DESCRIPTION
This shouldn't impact other operating systems, but will keep it playing nice with Windows.

Thanks!