### PR TITLE
Add node ESLint rule when server is custom

### DIFF
--- a/packages/create-lwc-app/templates/eslintrc.json
+++ b/packages/create-lwc-app/templates/eslintrc.json
@@ -6,5 +6,13 @@
         "@lwc/lwc/no-async-operation": "warn",
         "@lwc/lwc/no-inner-html": "warn",
         "@lwc/lwc/no-document-query": "warn"
-    }
+    }<% if (clientserver) { %>,
+    "overrides": [
+        {
+            "files": ["src/server/**"],
+            "env": {
+                "node": true
+            }
+        }
+    ]<% } %>
 }


### PR DESCRIPTION
When the user deploys a custom server, we need to configure ESLint for node for all files under `src/server/**`. If we don't do that, the user might get linting errors like the global `process` variable being considered as undefined.

I implemented that following a [Twitter conversation](https://twitter.com/emgforce__c/status/1181617919689662467) with a user who ran into issues while working on the Salesforce for JavaScript dev Trailhead projects.