### PR TITLE
Prettier commands had an extra backslash (fixes #386)

### DIFF
--- a/packages/create-lwc-app/src/generators/createGenerator.ts
+++ b/packages/create-lwc-app/src/generators/createGenerator.ts
@@ -266,9 +266,9 @@ class CreateGenerator extends Generator {
             this.pjson.scripts.lint = 'eslint ./src/**/*.js'
         }
         this.pjson.scripts.prettier =
-            'prettier --write \\"**/*.{css,html,js,json,md,ts,yaml,yml}"'
+            'prettier --write \"**/*.{css,html,js,json,md,ts,yaml,yml}"'
         this.pjson.scripts['prettier:verify'] =
-            'prettier --list-different \\"**/*.{css,html,js,json,md,ts,yaml,yml}"'
+            'prettier --list-different \"**/*.{css,html,js,json,md,ts,yaml,yml}"'
         if (this.clientserver) {
             if (this.typescript) {
                 this.pjson.scripts.build =


### PR DESCRIPTION
There was unnecessary backslash, attempting to escape a backslash, which causes the `prettier` and `prettier:verify` commands to fail to run (on Mac terminal, with unexpected EOF while parsing the command). Removing these backslashes should fix this.

Fixes #386 