### PR TITLE
Log error when loading configuration

### DIFF
--- a/packages/lwc-services/src/config/lwcConfig.ts
+++ b/packages/lwc-services/src/config/lwcConfig.ts
@@ -130,7 +130,8 @@ function buildConfig(): Config {
         combinedConfig = merge(defaultLwcConfig, config)
         return combinedConfig
     } catch (error) {
-        // We don't need error handling atm
+        console.error("Using default configuration! Error loading custom config");
+        console.error(error);
     }
     return combinedConfig
 }


### PR DESCRIPTION
Log when an error is encountered parsing or merging custom with the default configuration

It took me a while debugging to realize that this error was getting swallowed by LWC Services, and my custom config file was malformed and not parsing.