### PR TITLE
docs: add `lwcCompilerStylesheetConfig` to example

### DIFF
--- a/packages/lwc-services/example/lwc-services.config.js
+++ b/packages/lwc-services/example/lwc-services.config.js
@@ -39,5 +39,8 @@ module.exports = {
                 NODE_ENV: 'production'
             }
         }
+    },
+    lwcCompilerStylesheetConfig: {
+        customProperties: { allowDefinition: true }
     }
 }


### PR DESCRIPTION
It took me a while to find this available configuration. Eventually I found it here: https://github.com/muenzpraeger/create-lwc-app/commit/8485c1541508f967e3b82f5b2427309f55d02db9#diff-b860df3818fe1ada16fb692047786cfaR55

Mind adding it to the example config file? 