### PR TITLE
fix(): lwc transpile name and namespace from webpack

### DIFF
--- a/packages/lwc-services/src/utils/webpack/module.ts
+++ b/packages/lwc-services/src/utils/webpack/module.ts
@@ -18,14 +18,6 @@ function isValidModuleName(id: string) {
     return id.match(/^(\w+\/)(\w+)$/)
 }
 
-function getInfoFromId(id: string) {
-    const [ns, ...rest] = id.split('/')
-    return {
-        ns,
-        name: rest.join('/')
-    }
-}
-
 function getInfoFromPath(file: string, config: any) {
     const { path: root } = config.module
 
@@ -46,15 +38,15 @@ function getInfoFromPath(file: string, config: any) {
 
     const rel = relative(root, file)
     const parts = rel.split(sep)
-
-    const id = `${parts[0]}-${parts[1]}`
-
-    return getInfoFromId(id)
+    const end = parts.length - 1;
+    return {
+        ns: parts[end - 2],
+        name: parts[end - 1]
+    };
 }
 
 module.exports = {
     getConfig,
     isValidModuleName,
-    getInfoFromId,
     getInfoFromPath
 }

--- a/packages/lwc-webpack-plugin/src/loader.ts
+++ b/packages/lwc-webpack-plugin/src/loader.ts
@@ -50,8 +50,8 @@ module.exports = function (source: any) {
 
     compiler
         .transform(codeTransformed, resourcePath, {
-            name: info.ns,
-            namespace: 'my',
+            name: info.name,
+            namespace: info.ns,
             stylesheetConfig,
             outputConfig,
             experimentalDynamicComponent

--- a/packages/lwc-webpack-plugin/src/module.ts
+++ b/packages/lwc-webpack-plugin/src/module.ts
@@ -18,14 +18,6 @@ function isValidModuleName(id: string) {
     return id.match(/^(\w+\/)(\w+)$/)
 }
 
-function getInfoFromId(id: string) {
-    const [ns, ...rest] = id.split('/')
-    return {
-        ns,
-        name: rest.join('/')
-    }
-}
-
 function getInfoFromPath(file: string, root: string) {
     if (!file.startsWith(root)) {
         let jsFile = file
@@ -44,15 +36,15 @@ function getInfoFromPath(file: string, root: string) {
 
     const rel = relative(root, file)
     const parts = rel.split(sep)
-
-    const id = `${parts[2]}-${parts[3]}`
-
-    return getInfoFromId(id)
+    const end = parts.length - 1;
+    return {
+        ns: parts[end - 2],
+        name: parts[end - 1]
+    };
 }
 
 module.exports = {
     getConfig,
     isValidModuleName,
-    getInfoFromId,
     getInfoFromPath
 }


### PR DESCRIPTION
The name and namespace parameters for the lwc compiler.transpile call in webpack were being improperly computed. They could contain a dot character which would result in component tags with attributes that could not be selected by the generated css selectors.