### PR TITLE
Fix lwc-webpack-plugin preset definition

### DIFF
--- a/packages/lwc-webpack-plugin/src/loader.ts
+++ b/packages/lwc-webpack-plugin/src/loader.ts
@@ -37,10 +37,12 @@ module.exports = function (source: any) {
                 )
             ],
             presets: [
-                require.resolve('@babel/preset-typescript'),
-                {
-                    allowDeclareFields: true
-                }
+                [
+                    require.resolve('@babel/preset-typescript'),
+                    {
+                        allowDeclareFields: true
+                    }
+                ]
             ]
         })
         codeTransformed = code


### PR DESCRIPTION
This is causing the following error:

```
Unhandled Rejection (Error): Module build failed (from ./node_modules/lwc-services/node_modules/lwc-webpack-plugin/dist/loader.js):
Error: [BABEL] /home/sbatista/Dev/Salesforce/lightning-wired-frontend/src/components/page/container/container.ts: Unknown option: .allowDeclareFields. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
- Maybe you meant to use
"preset": [
  ["/home/sbatista/Dev/Salesforce/lightning-wired-frontend/node_modules/lwc-services/node_modules/@babel/preset-typescript/lib/index.js", {
  "allowDeclareFields": true
}]
]
```

It's a bummer this regression made it into the library. Not sure how, but it would be nice if we had some tests to prevents issues like this from cropping up. 