### PR TITLE
fix: add support for light DOM scoped styles

### DIFF
--- a/packages/lwc-webpack-plugin/src/loader.ts
+++ b/packages/lwc-webpack-plugin/src/loader.ts
@@ -56,7 +56,8 @@ module.exports = function (source: any) {
             namespace: info.ns,
             stylesheetConfig,
             outputConfig,
-            experimentalDynamicComponent
+            experimentalDynamicComponent,
+            scopedStyles: resourcePath.endsWith('.scoped.css')
         })
         .then((res: any) => {
             cb(null, res.code)


### PR DESCRIPTION
This adds support for light DOM scoped styles (https://github.com/salesforce/lwc/pull/2332), which will be released in the next version of LWC.

I didn't see any tests, so to confirm that this is working, I made a little "hello world" app and used light DOM scoped styles for the `<my-greeting>` component:

![Screen Shot 2021-09-17 at 11 04 29 AM](https://user-images.githubusercontent.com/283842/133834334-aa77470e-8854-430f-b287-e1e22464464a.png)

W-9507397