### PR TITLE
fix: remove deprecated outputConfig.minify

### DIFF
--- a/packages/lwc-services/example/lwc-services.config.js
+++ b/packages/lwc-services/example/lwc-services.config.js
@@ -34,7 +34,6 @@ module.exports = {
     lwcCompilerOutput: {
         production: {
             compat: false,
-            minify: true,
             env: {
                 NODE_ENV: 'production'
             }

--- a/packages/lwc-services/src/config/lwcConfig.ts
+++ b/packages/lwc-services/src/config/lwcConfig.ts
@@ -32,7 +32,6 @@ interface Config {
     lwcCompilerOutput: {
         development?: {
             compat?: boolean
-            minify?: boolean
             env?: {
                 NODE_ENV: string
             }
@@ -40,7 +39,6 @@ interface Config {
         }
         production?: {
             compat?: boolean
-            minify?: boolean
             env?: {
                 NODE_ENV: string
             }
@@ -78,7 +76,6 @@ export const defaultLwcConfig: Config = {
     lwcCompilerOutput: {
         development: {
             compat: false,
-            minify: true,
             env: {
                 NODE_ENV: 'production'
             },
@@ -86,7 +83,6 @@ export const defaultLwcConfig: Config = {
         },
         production: {
             compat: false,
-            minify: true,
             env: {
                 NODE_ENV: 'production'
             },


### PR DESCRIPTION
The `outputConfig.minify` property has been deprecated and does nothing in recent versions of LWC (https://github.com/salesforce/lwc/pull/2380). Instead, it logs a warning:

    "OutputConfig.minify" property is deprecated. The value doesn't impact the compilation and can safely be removed.

This PR removes the property and thus the warning.