### PR TITLE
fix: fix missing getInfoFromId

### DIFF
--- a/packages/lwc-services/src/utils/webpack/module.ts
+++ b/packages/lwc-services/src/utils/webpack/module.ts
@@ -45,8 +45,17 @@ function getInfoFromPath(file: string, config: any) {
     }
 }
 
+function getInfoFromId(id: string) {
+    const [ns, ...rest] = id.split('/')
+    return {
+        ns,
+        name: rest.join('/')
+    }
+}
+
 module.exports = {
     getConfig,
     isValidModuleName,
-    getInfoFromPath
+    getInfoFromPath,
+    getInfoFromId
 }


### PR DESCRIPTION
In https://github.com/muenzpraeger/create-lwc-app/commit/8eed261d89b44fb92326cba32e8b34150508b622, the function `getInfoFromId` was removed from [`module.ts`](https://github.com/muenzpraeger/create-lwc-app/blob/main/packages/lwc-services/src/utils/webpack/module.ts). But it's still referenced here:

https://github.com/muenzpraeger/create-lwc-app/blob/21047b22f80631feafa6eca6e9a80bf971d0f4a0/packages/lwc-services/src/utils/resolver.ts#L51

This leads to an error when running `yarn test:unit` in an app created by `create-lwc-app`:

    Cannot find module 'my/app' from 'src/client/modules/my/app/__tests__/app.test.js'

This PR fixes the error by adding `getInfoFromId` back to `module.ts`.